### PR TITLE
Replaces HTACCESS rules in nginx rewrites

### DIFF
--- a/nginx-config.txt
+++ b/nginx-config.txt
@@ -1,0 +1,9 @@
++Here is the rewrite you need to run REST requests on nginx
++You should include that in your .conf file of your server host file 
++(usually in ..sites-enabled/YOURVHOST.conf)
++
++#Replaces HTACCESS rules in nginx rewrites
++#-------------------
++rewrite ^(.*) /index.php?$1;
++#-------------------
++


### PR DESCRIPTION
If you are using NginX instead of Apache server, you will need to replace the .htaccess rules with NginX style rules.
Read this file for the example rule.